### PR TITLE
set explicit json output format

### DIFF
--- a/bin/awsmfa.js
+++ b/bin/awsmfa.js
@@ -65,14 +65,14 @@ if (!mfaArn) {
 }
 
 try {
-    const credString = execSync(
-        `aws --profile ${profile} sts get-session-token \
-             --serial-number ${mfaArn} \
-             --token-code ${token} \
-             --duration-seconds ${duration}`
-    );
-
-    creds = JSON.parse(credString).Credentials;
+  const credString = execSync(
+    `aws --profile ${profile} sts get-session-token \
+    --serial-number ${mfaArn} \
+    --token-code ${token} \
+    --duration-seconds ${duration} \
+    --output json`
+  );
+  creds = JSON.parse(credString).Credentials;
 } catch (e) {
     console.error(e.message);
     process.exit(1);


### PR DESCRIPTION
Configuring `output = table` in ~/.aws/config interferes with the `...sts get-session-token...` call and awsmfa can't parse the output. 

Set `--output json` explicitly.