### PR TITLE
Env variable cache file option

### DIFF
--- a/bin/awsmfa.js
+++ b/bin/awsmfa.js
@@ -1,67 +1,71 @@
 #!/usr/bin/env node
 
-const execSync = require('child_process').execSync;
-const fs = require('fs');
+const execSync = require('child_process').execSync
+const fs = require('fs')
 
-const profile = process.argv[2];
-const token = process.argv[3];
-const duration = 86400;
+const profile = process.argv[2]
+const token = process.argv[3]
+const duration = 86400
 
-let creds;
-let credentials;
+let creds
+let credentials
 
-const credentialsFile = `${process.env.HOME}/.aws/credentials`;
+const credentialsFile = `${process.env.HOME}/.aws/credentials`
+const cacheEnabled = process.env.AWSMFA_CACHE_ENABLED || false
+const timeoutFile = `${process.env.AWSMFA_TIMEOUT_FILE}`
 
 if (!token) {
-  console.error('Error: no token provided');
-  process.exit(2);
+  console.error('Error: no token provided')
+  process.exit(2)
 }
 
 if (!profile) {
-  console.error('Error: no profile provided');
-  process.exit(2);
+  console.error('Error: no profile provided')
+  process.exit(2)
 }
 
 try {
-  credentials = fs.readFileSync(credentialsFile, 'utf8');
+  credentials = fs.readFileSync(credentialsFile, 'utf8')
 } catch (e) {
-  console.error("Error: couldn't open credentials file");
-  console.error(e.message);
-  process.exit(3);
+  console.error("Error: couldn't open credentials file")
+  console.error(e.message)
+  process.exit(3)
 }
 
-const lines = credentials.split('\n');
+const lines = credentials.split('\n')
 
-const headerRegex = /\[(.*)\]/;
-const optionRegex = /(.*)=(.*)/;
+const headerRegex = /\[(.*)\]/
+const optionRegex = /(.*)=(.*)/
 
-let currentProfile = '';
+let currentProfile = ''
+let currentProfileTimeout
+
 const config = lines.reduce((acc, line) => {
-  const headerMatch = headerRegex.exec(line.trim());
+  const headerMatch = headerRegex.exec(line.trim())
   if (headerMatch) {
-    currentProfile = headerMatch[1];
-    acc[currentProfile] = {};
+    currentProfile = headerMatch[1]
+    acc[currentProfile] = {}
   } else {
-    const optionMatch = optionRegex.exec(line.trim());
+    const optionMatch = optionRegex.exec(line.trim())
     if (optionMatch) {
-      const key = optionMatch[1].trim();
-      const value = optionMatch[2].trim();
-      acc[currentProfile][key] = value;
+      const key = optionMatch[1].trim()
+      const value = optionMatch[2].trim()
+      acc[currentProfile][key] = value
     }
   }
-  return acc;
-}, {});
+  return acc
+}, {})
 
 if (!config[profile]) {
-  console.error(`Error: profile ${profile} not found in credentials file`);
-  process.exit(4);
+  console.error(`Error: profile ${profile} not found in credentials file`)
+  process.exit(4)
 }
 
 const mfaArn = config[profile].mfa_arn;
 
 if (!mfaArn) {
-  console.error(`Error: no mfa_arn defined for profile ${profile}`);
-  process.exit(5);
+  console.error(`Error: no mfa_arn defined for profile ${profile}`)
+  process.exit(5)
 }
 
 try {
@@ -71,28 +75,37 @@ try {
     --token-code ${token} \
     --duration-seconds ${duration} \
     --output json`
-  );
-  creds = JSON.parse(credString).Credentials;
+  )
+
+  creds = JSON.parse(credString).Credentials
+  const now = new Date().getTime() / 1000
+  currentProfileTimeout = new Date(creds.Expiration).getTime() / 1000
+
 } catch (e) {
-  console.error(e.message);
-  process.exit(1);
+  console.error(e.message)
+  process.exit(1)
 }
 
 config.default = {
   aws_access_key_id: creds.AccessKeyId,
   aws_secret_access_key: creds.SecretAccessKey,
   aws_session_token: creds.SessionToken
-};
+}
 
 configString = Object.keys(config).reduce((acc, profile) => {
   acc += `
 
-[${profile}]`;
+[${profile}]`
     Object.keys(config[profile]).forEach(key => {
       acc += `
-${key} = ${config[profile][key]}`;
-    });
-    return acc;
-}, '');
+${key} = ${config[profile][key]}`
+    })
+    return acc
+}, '')
+fs.writeFileSync(credentialsFile, configString)
 
-fs.writeFileSync(credentialsFile, configString);
+if (cacheEnabled) {
+  let exportString = `export AWSMFA_EXPIRE_EPOCH=${currentProfileTimeout}\n`
+  exportString += `export AWSMFA_PROFILE=${profile}\n`
+  fs.writeFileSync(timeoutFile, exportString)
+}

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ npm i -g @notbrain/awsmfa (COMING SOON)
 ```
 git clone --depth 1 https://github.com/notbrain/awsmfa
 cd awsmfa
-npm i -g 
+npm i -g
 ```
 
 ## Requirements
@@ -54,3 +54,21 @@ aws_session_token = FQoDYXdzENj//////////wEaDBSRyXR9SFAmXO/r/yKwAVDM2JNEGzIT4xAc
 ```
 
 Now, when you use the AWS CLI, it defaults to using the session you last started. If you think what this package offers is too simplistic and you want more control, check out [broamski/aws-mfa](https://github.com/broamski/aws-mfa).
+
+## Shell Variable Export Option
+
+If you set `AWSMFA_CACHE_ENABLED=true`, awsmfa will create a file named whatever the value of `AWSMFA_TIMEOUT_FILE` is. For example if you set:
+
+```
+AWSMFA_CACHE_ENABLED=true|false
+AWSMFA_TIMEOUT_FILE="$HOME/.awsmfa/timeout"
+```
+
+The file `$HOME/.awsmfa/timeout` will contain
+
+```
+export AWSMFA_EXPIRE_EPOCH=<epoch_of_expiration>
+export AWSMFA_PROFILE=<profile_name>
+```
+
+which can be used to calculate the expiration time and current profile active for use in custom shell prompts.


### PR DESCRIPTION
Added support for storing the epoch time in seconds into a shell variable so shell prompt integrations  do not need to call aws iam get-user on every new prompt. They can now just show the seconds remaining on the token lease. 

Example `[voltaint <expiration>]` expiring in 85509 seconds:

![image](https://user-images.githubusercontent.com/67282/84159976-89755700-aa22-11ea-86e4-da52f106c49e.png)

Variables required in shell:

`AWSMFA_CACHE_ENABLED=true|false`
`AWSMFA_TIMEOUT_FILE="$HOME/.awsmfa/timeout"`

Inside `AWSMFA_TIMEOUT_FILE`, for use in bash or zsh, etc to calc token expiry:

```
export AWSMFA_EXPIRE_EPOCH=<epoch>
export AWSMFA_PROFILE=<profile_name>
```